### PR TITLE
Set temperature=0.0 to ensure reproducibility in evaluation

### DIFF
--- a/Evaluation-Scripts/LLM_Judge_evaluation.py
+++ b/Evaluation-Scripts/LLM_Judge_evaluation.py
@@ -37,6 +37,7 @@ def annotate(prediction_set, filename, output_dir):
                 # Compute the correctness score
                 completion = openai.ChatCompletion.create(
                     model="GPT-3.5-turbo-0125",
+                    temperature=0.0,
                     messages=[
                         {
                             "role": "system",


### PR DESCRIPTION
To improve the reproducibility of the evaluation results, I suggest explicitly setting temperature=0.0.
Currently, the code does not specify a temperature, which defaults to temperature=1.0. 
This setting introduces randomness, which can lead to inconsistent outputs during evaluation.
By setting temperature=0.0, we can minimize randomness and ensure that the model's responses remain consistent across runs.

Please review this change.
Thank you!